### PR TITLE
fix(grabber_visualcrossing.pl): skip past hours only for current day

### DIFF
--- a/bin/grabber_visualcrossing.pl
+++ b/bin/grabber_visualcrossing.pl
@@ -416,11 +416,13 @@ open(F,">$lbplogdir/hourlyforecast.dat.tmp") or $error = 1;
 	for my $resultsdays ( @{$decoded_json->{days}} ){
 		for my $results( @{$resultsdays->{hours}} ){
 			# Skip first datasets of current day
-			my $now = localtime;
+			local $ENV{TZ} = $decoded_json->{timezone};
+			my $now = localtime();
 			my $hfctime = localtime($results->{datetimeEpoch});
-			if ($now->hour > $hfctime->hour) {
-				next;
+			if ( $hfctime->ymd eq $now->ymd && $results->{datetimeEpoch} < $now->epoch ) {
+			    next;
 			}
+			
 			print F "$i|";
 			$i++;
 			print F $results->{datetimeEpoch}, "|";


### PR DESCRIPTION
- Previously the script skipped all hours with hour < current hour, regardless of date
- This resulted in hourlyforecast.dat containing only entries from now until midnight for each day
- This also led to incorrect calc+ values, because they were computed from incomplete hourly datasets
- Added proper date+epoch comparison in the location’s timezone
- Now only past hours of the current day are skipped, future days include full 24h forecast