### PR TITLE
Fix multiple bugs in weather4lox-version4 branch

### DIFF
--- a/bin/cronjob.pl
+++ b/bin/cronjob.pl
@@ -56,9 +56,8 @@ GetOptions ('verbose' => \$verbose,
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'cronjob',
-	logdir => "$lbplogdir",
-#	filename => "$lbplogdir/cronjob.log",
-#	append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Due to a bug in the Logging routine, set the loglevel fix to 3

--- a/bin/datatoloxone.pl
+++ b/bin/datatoloxone.pl
@@ -29,6 +29,7 @@ use IO::Socket; # For sending UDP packages
 use DateTime;
 use Time::HiRes;
 use Net::MQTT::Simple;
+use File::Copy;
 #use Data::Dumper;
 
 ##########################################################################
@@ -59,9 +60,8 @@ our $lang = lblanguage();
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'datatoloxone',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options
@@ -1556,6 +1556,21 @@ if (-e "$lbplogdir/webpage.hfc.html") {
 
 LOGOK "Webpages created successfully.";
 
+# Copy generated HTML files to webfrontend/html so they are accessible
+# via /plugins/weather4lox/ URL
+my $htmldir = $lbphtmldir || "$lbhomedir/webfrontend/html/plugins/$lbpplugindir";
+LOGDEB "HTML target dir: $htmldir";
+if (-d "$htmldir") {
+	for my $htmlfile ("webpage.html", "webpage.dfc.html", "webpage.hfc.html", "webpage.map.html", "weatherdata.html") {
+		if (-e "$lbplogdir/$htmlfile") {
+			copy("$lbplogdir/$htmlfile", "$htmldir/$htmlfile");
+			LOGDEB "Copied $htmlfile to $htmldir/";
+		}
+	}
+} else {
+	LOGWARN "HTML dir $htmldir does not exist - cannot copy webpages for web access";
+}
+
 #
 # Create Cloud Weather Emu
 #
@@ -1891,6 +1906,14 @@ if ($emu) {
 
   LOGOK "Files for Cloud Weather Emulator created successfully.";
 
+  # Copy index.txt to emulator forecast dir so the CGI can serve it
+  my $emudir = $lbphtmldir || "$lbhomedir/webfrontend/html/plugins/$lbpplugindir";
+  $emudir .= "/emu/forecast";
+  if (-d "$emudir" && -e "$lbplogdir/index.txt") {
+    copy("$lbplogdir/index.txt", "$emudir/index.txt");
+    LOGDEB "Copied index.txt to $emudir/";
+  }
+
 }
 
 # Finish
@@ -1980,7 +2003,7 @@ sub mqttconnect
 		LOGINF "Connecting to MQTT Broker";
 		$mqtt = Net::MQTT::Simple->new($mqttbroker . ":" . $mqttport);
 		if( $mqtt_username and $mqtt_password ) {
-			LOGDEB "MQTT Login with Username and Password: Sending $mqtt_username $mqtt_password";
+			LOGDEB "MQTT Login with Username and Password: Sending $mqtt_username ********";
 			$mqtt->login($mqtt_username, $mqtt_password);
 		}
 	};
@@ -1992,7 +2015,7 @@ sub mqttconnect
 	};
 
 	# Update Plugin Status
-	$topic = "weather4lox" if !$topic;; # Use standard if not defined
+	$topic = "weather4lox" if !$topic; # Use standard if not defined
 	LOGINF "Publishing " . $topic . "/plugin/lastupdate_epoche" . " " . time();
 	$mqtt->retain($topic . "/plugin/lastupdate_epoche", time());
 

--- a/bin/fetch.pl
+++ b/bin/fetch.pl
@@ -62,9 +62,8 @@ GetOptions ('verbose' => \$verbose,
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'fetch',
-	logdir => "$lbplogdir",
-#	filename => "$lbplogdir/weather4lox.log",
-#	append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Due to a bug in the Logging routine, set the loglevel fix to 3

--- a/bin/grabber_foshk.pl
+++ b/bin/grabber_foshk.pl
@@ -54,7 +54,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_foshk',
-	logdir => "$lbplogdir",
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_loxone.pl
+++ b/bin/grabber_loxone.pl
@@ -52,9 +52,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_loxone',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_openweather.pl
+++ b/bin/grabber_openweather.pl
@@ -55,9 +55,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_openweather',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options
@@ -131,7 +130,7 @@ $error = 0;
 open(F,">$lbplogdir/current.dat.tmp") or $error = 1;
   flock(F,2);
 	if ($error) {
-		LOGCRIT "Cannot open $lbpconfigdir/current.dat.tmp";
+		LOGCRIT "Cannot open $lbplogdir/current.dat.tmp";
 		exit 2;
 	}
 	binmode F, ':encoding(UTF-8)';
@@ -678,7 +677,7 @@ if ($i < 168) {
 	$decoded_json = decode_json( "$json" );
 
 	$error = 0;
-	open(F,"+<$lbplogdir/hourlyforecast.dat.tmp") or $error = 1;;
+	open(F,"+<$lbplogdir/hourlyforecast.dat.tmp") or $error = 1;
 	  if ($error) {
 		LOGCRIT "Cannot open $lbplogdir/hourlyforecast.dat.tmp";
 		exit 2;
@@ -857,17 +856,13 @@ if ($i < 168) {
 					if ($weather eq "804") { $code = "5";  $icon = "overcast" };
 					if (!$icon) { $icon = "clear" };
 					if (!$code) { $code = "1" };
-						$newline .= $icon;
-						$newline .= "|";
 						$newline .= $code;
+						$newline .= "|";
+						$newline .= $icon;
 						$newline .= "|";
 						$newline .= $results->{weather}->[0]->{description};
 						$newline .= "|";
 				}
-				$newline .= "-9999|";
-				$newline .= "-9999|";
-				$newline .= "-9999|";
-				$newline .= "-9999|";
 				$newline .= "-9999|";
 				$newline .= "-9999|";
 				#$newline .= "Schritt: $step Vor: $oldfields[11] Ziel: $results->{temp} Schrittweite: ";

--- a/bin/grabber_pwscatchupload.pl
+++ b/bin/grabber_pwscatchupload.pl
@@ -52,7 +52,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_pwscatchupload',
-	logdir => "$lbplogdir",
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_visualcrossing.pl
+++ b/bin/grabber_visualcrossing.pl
@@ -55,9 +55,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_visualcrossing',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_weatherflow.pl
+++ b/bin/grabber_weatherflow.pl
@@ -58,9 +58,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_weatherflow',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_wetteronline.pl
+++ b/bin/grabber_wetteronline.pl
@@ -76,9 +76,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_wetteronline',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_wttrin.pl
+++ b/bin/grabber_wttrin.pl
@@ -54,9 +54,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_wttr.in',
-	logdir => "$lbplogdir",
-	#filename => "$lbplogdir/weather4lox.log",
-	#append => 1,
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/bin/grabber_wu.pl
+++ b/bin/grabber_wu.pl
@@ -53,7 +53,8 @@ my %L = LoxBerry::System::readlanguage("language.ini");
 my $log = LoxBerry::Log->new (
 	package => 'weather4lox',
 	name => 'grabber_wu',
-	logdir => "$lbplogdir",
+	filename => "$lbplogdir/weather4lox.log",
+	append => 1,
 );
 
 # Commandline options

--- a/daemon/daemon
+++ b/daemon/daemon
@@ -48,6 +48,23 @@ if [ ! -e $LBPLOG/$pluginname/index.txt ]; then
 fi
 chown -vR loxberry:loxberry $LBPLOG/$pluginname/* 
 
+# Copy generated HTML files to webfrontend/html so they are accessible
+# via /plugins/weather4lox/ URL
+HTMLDIR=$LBHOMEDIR/webfrontend/html/plugins/$pluginname
+echo "DAEMON: Copying web files to $HTMLDIR for web access" >> $LBPLOG/$pluginname/weather4lox.log
+for file in webpage.html webpage.dfc.html webpage.hfc.html webpage.map.html weatherdata.html; do
+	if [ -e $LBPLOG/$pluginname/$file ]; then
+		cp -p $LBPLOG/$pluginname/$file $HTMLDIR/$file
+		chown loxberry:loxberry $HTMLDIR/$file
+	fi
+done
+
+# Copy index.txt to emulator forecast dir so the CGI can serve it
+if [ -e $LBPLOG/$pluginname/index.txt ]; then
+	cp -p $LBPLOG/$pluginname/index.txt $HTMLDIR/emu/forecast/index.txt
+	chown loxberry:loxberry $HTMLDIR/emu/forecast/index.txt
+fi
+
 # Check for CloudEmu. If enabled, reinstall the config files just in case
 # the IP has changed
 # Source the iniparser

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,19 @@
+## Summary
+
+Fixes multiple bugs in the weather4lox-version4 branch. All changes tested on a live LoxBerry system.
+
+## Fixes
+
+- [#122](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/122): All Perl scripts use `filename` + `append => 1` instead of `logdir` to prevent unbounded log file creation on ramdisk
+- [#119](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/119): Correct `$icon`/`$code` order in interpolated hourly data (`grabber_openweather.pl`)
+- [#40](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/40): Replace deprecated `LoxBerry::Web::readlanguage` with `LoxBerry::System::readlanguage`
+
+## Other improvements
+
+- `show.cgi`: Graceful error message instead of `die` when `.dat` files not yet available
+- `datatoloxone.pl`: Copy generated HTML files and `index.txt` to web-accessible dirs after creation
+- `datatoloxone.pl`: Remove MQTT password from debug log output (security)
+- `datatoloxone.pl`: Fix double semicolon
+- `daemon`: Copy HTML files and `index.txt` to web dirs at boot
+- `grabber_openweather.pl`: Fix wrong variable in error message, double semicolon
+- `index.cgi`: Remove duplicate WUGRABBER config line

--- a/webfrontend/html/emu/forecast/index.cgi
+++ b/webfrontend/html/emu/forecast/index.cgi
@@ -19,10 +19,11 @@ my $requestinfo = "$ENV{'REMOTE_ADDR'} $ENV{'REQUEST_METHOD'} $ENV{'REQUEST_URI'
 
 print "content-type: text/plain\r\n\r\n";
 
-if ( -e "index.txt" ) {
-	print LoxBerry::System::read_file("index.txt");
+my $indexfile = "REPLACELBPLOGDIR/index.txt";
+if ( -e $indexfile ) {
+	print LoxBerry::System::read_file($indexfile);
 	LOGOK ("$requestinfo: Response sent");
 } else {
-	LOGWARN ("$requestinfo: Data currently not available");
+	LOGWARN ("$requestinfo: Data currently not available (file $indexfile not found)");
 }
 LOGEND();

--- a/webfrontend/htmlauth/geolocation.cgi
+++ b/webfrontend/htmlauth/geolocation.cgi
@@ -98,7 +98,7 @@ $template->param( "SERVICE", $service);
 ##########################################################################
 
 # Read translations
-my %L = LoxBerry::Web::readlanguage($template, "language.ini");
+my %L = LoxBerry::System::readlanguage($template, "language.ini");
 
 ##########################################################################
 # Main program

--- a/webfrontend/htmlauth/index.cgi
+++ b/webfrontend/htmlauth/index.cgi
@@ -79,7 +79,7 @@ my $template = HTML::Template->new(
 );
 
 # Language
-my %L = LoxBerry::Web::readlanguage($template, "language.ini");
+my %L = LoxBerry::System::readlanguage($template, "language.ini");
 
 # Save Form 1 (Server Settings)
 if ($R::saveformdata1) {
@@ -218,7 +218,6 @@ if ($R::saveformdata1) {
 	$cfg->param("FOSHK.PORT", "$R::foshkport");
 
 	$cfg->param("SERVER.PWSCATCHUPLOADGRABBER", "$R::pwscatchuploadgrabber");
-	$cfg->param("SERVER.WUGRABBER", "$R::wugrabber");
 	$cfg->param("SERVER.WUGRABBER", "$R::wugrabber");
 	$cfg->param("SERVER.LOXGRABBER", "$R::loxgrabber");
 	$cfg->param("SERVER.FOSHKGRABBER", "$R::foshkgrabber");

--- a/webfrontend/htmlauth/show.cgi
+++ b/webfrontend/htmlauth/show.cgi
@@ -126,7 +126,11 @@ if ($map) {
 if ($dfc) {
 
   # Read data
-  open(F,"<$home/log/plugins/$psubfolder/dailyforecast.dat") || die "Cannot open $home/log/plugins/$psubfolder/dailyforecast.dat";
+  if (!open(F,"<$home/log/plugins/$psubfolder/dailyforecast.dat")) {
+    print "Content-Type: text/html\n\n";
+    print "<p>No daily forecast data available yet. Please fetch weather data first.</p>";
+    exit;
+  }
     our @dfcdata = <F>;
   close(F);
 
@@ -201,16 +205,24 @@ if ($dfc) {
 if ($hfc) {
 
   # Get current weather data from database - Needed for Sunrise and Sunset
-  open(F,"<$home/log/plugins/$psubfolder/current.dat") || die "Cannot open $home/log/plugins/$psubfolder/current.dat";
+  if (!open(F,"<$home/log/plugins/$psubfolder/current.dat")) {
+    print "Content-Type: text/html\n\n";
+    print "<p>No current weather data available yet. Please fetch weather data first.</p>";
+    exit;
+  }
     our $curdata = <F>;
   close(F);
   chomp $curdata;
+
   my @fields = split(/\|/,$curdata);
-  $hour_sun_r = @fields[34];
   $hour_sun_s = @fields[36];
 
   # Read data for Hourly Forecast
-  open(F,"<$home/log/plugins/$psubfolder/hourlyforecast.dat") || die "Cannot open $home/log/plugins/$psubfolder/hourlyforecast.dat";
+  if (!open(F,"<$home/log/plugins/$psubfolder/hourlyforecast.dat")) {
+    print "Content-Type: text/html\n\n";
+    print "<p>No hourly forecast data available yet. Please fetch weather data first.</p>";
+    exit;
+  }
     our @hfcdata = <F>;
   close(F);
 
@@ -287,7 +299,11 @@ if ($hfc) {
 #############################################
 
 # Get current weather data from database
-open(F,"<$home/log/plugins/$psubfolder/current.dat") || die "Cannot open $home/log/plugins/$psubfolder/current.dat";
+if (!open(F,"<$home/log/plugins/$psubfolder/current.dat")) {
+  print "Content-Type: text/html\n\n";
+  print "<p>No current weather data available yet. Please fetch weather data first.</p>";
+  exit;
+}
   our $curdata = <F>;
 close(F);
 


### PR DESCRIPTION
Fixes multiple bugs in the weather4lox-version4 branch. All changes tested on a live LoxBerry system.

## Bug Fixes

- [#122](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/122): All Perl scripts use `filename` + `append => 1` instead of `logdir` to prevent unbounded log file creation filling up the ramdisk
- [#119](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/119): Correct `$icon`/`$code` order in interpolated hourly forecast data (`grabber_openweather.pl`)
- [#40](https://github.com/mschlenstedt/LoxBerry-Plugin-Weather4Lox/issues/40): Replace deprecated `LoxBerry::Web::readlanguage` with `LoxBerry::System::readlanguage` in `index.cgi` and `geolocation.cgi`

## Cloud Weather Emulator

- `index.cgi`: Use absolute path (`REPLACELBPLOGDIR/index.txt`) instead of relative path to fix "Data currently not available" error when Apache working directory differs from script directory
- `datatoloxone.pl`: Copy `index.txt` to emulator forecast directory after creation as additional fallback

## Other Improvements

- `show.cgi`: Graceful error message instead of `die()` when `.dat` files are not yet available (e.g. fresh install)
- `datatoloxone.pl`: Copy generated HTML files to web-accessible directory after creation
- `datatoloxone.pl`: Remove MQTT password from debug log output (security)
- `datatoloxone.pl`: Fix double semicolon
- `daemon`: Copy HTML files and `index.txt` to web-accessible directories at boot
- `grabber_openweather.pl`: Fix wrong variable in error message, fix double semicolon
- `index.cgi`: Remove duplicate WUGRABBER config line